### PR TITLE
サーチ機能の追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,15 @@ COPY --from=builder /app/node_modules/kuromoji/dict ./node_modules/kuromoji/dict
 # transformersモデルキャッシュ（存在する場合）
 COPY --from=builder /app/.cache ./.cache
 
-RUN ln -s /tmp/cache ./.next/cache
+RUN ln -s /tmp/cache ./.next/cache && \
+    # transformersキャッシュ用の書き込み可能なディレクトリを作成
+    mkdir -p /tmp/cache/transformers && \
+    # .cacheディレクトリの権限を設定（読み取り専用として使用、書き込みは/tmp/cache/transformersを使用）
+    chown -R node:node /tmp/cache && \
+    chown -R node:node ./.cache || true
+
+# transformersキャッシュを書き込み可能なディレクトリに設定
+ENV TRANSFORMERS_CACHE=/tmp/cache/transformers
 
 USER node
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,16 @@ COPY --from=builder /app/public ./public
 COPY --from=builder /app/run.sh ./run.sh
 # for Auth0
 COPY --from=builder /app/.env.production.local ./.env.production.local
+
+# 検索インデックス
+COPY --from=builder /app/data ./data
+
+# kuromoji辞書（形態素解析用）
+COPY --from=builder /app/node_modules/kuromoji/dict ./node_modules/kuromoji/dict
+
+# transformersモデルキャッシュ（存在する場合）
+COPY --from=builder /app/.cache ./.cache
+
 RUN ln -s /tmp/cache ./.next/cache
 
 USER node

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { search, vectorSearch, hybridSearch, type SearchOptions } from '@/lib/search/orama-client';
+import { auth0 } from '@/lib/auth0';
 
 export const dynamic = 'force-dynamic';
 
@@ -13,6 +14,15 @@ type ContentType = typeof VALID_CONTENT_TYPES[number];
 
 export async function GET(request: NextRequest) {
   try {
+    // 認証チェック
+    const session = await auth0.getSession();
+    if (!session) {
+      return NextResponse.json(
+        { error: '検索機能を利用するにはログインが必要です' },
+        { status: 401 }
+      );
+    }
+
     const searchParams = request.nextUrl.searchParams;
     const query = searchParams.get('q');
     const type = searchParams.get('type') as SearchType | null;

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -57,7 +57,8 @@ export async function GET(request: NextRequest) {
       : 'all';
 
     // 件数のバリデーション
-    const limit = limitParam ? Math.min(Math.max(1, parseInt(limitParam, 10)), 50) : 20;
+    const parsedLimit = limitParam ? parseInt(limitParam, 10) : NaN;
+    const limit = Number.isNaN(parsedLimit) ? 20 : Math.min(Math.max(1, parsedLimit), 50);
 
     // タグのパース
     const tags = tagsParam ? tagsParam.split(',').map(t => t.trim()).filter(t => t.length > 0) : undefined;

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { search, vectorSearch, hybridSearch, type SearchOptions } from '@/lib/search/orama-client';
+import { search, vectorSearch, hybridSearch, type SearchOptions, type SearchResponse } from '@/lib/search/orama-client';
 import { auth0 } from '@/lib/auth0';
 
 export const dynamic = 'force-dynamic';
@@ -71,22 +71,22 @@ export async function GET(request: NextRequest) {
     };
 
     // 検索実行
-    let results;
+    let searchResponse: SearchResponse;
     switch (searchType) {
       case 'fulltext':
-        results = await search(query, options);
+        searchResponse = await search(query, options);
         break;
       case 'vector':
-        results = await vectorSearch(query, options);
+        searchResponse = await vectorSearch(query, options);
         break;
       case 'hybrid':
       default:
-        results = await hybridSearch(query, options);
+        searchResponse = await hybridSearch(query, options);
         break;
     }
 
     // レスポンスの整形（contentは長いので短縮）
-    const formattedResults = results.map(result => ({
+    const formattedResults = searchResponse.results.map(result => ({
       id: result.id,
       type: result.type,
       title: result.title,
@@ -103,7 +103,7 @@ export async function GET(request: NextRequest) {
       query,
       searchType,
       contentType: validatedContentType,
-      total: formattedResults.length,
+      total: searchResponse.total,
       results: formattedResults,
     });
 

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,0 +1,107 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { search, vectorSearch, hybridSearch, type SearchOptions } from '@/lib/search/orama-client';
+
+export const dynamic = 'force-dynamic';
+
+// 検索タイプのバリデーション
+const VALID_SEARCH_TYPES = ['hybrid', 'fulltext', 'vector'] as const;
+type SearchType = typeof VALID_SEARCH_TYPES[number];
+
+// コンテンツタイプのバリデーション
+const VALID_CONTENT_TYPES = ['quiz', 'text', 'all'] as const;
+type ContentType = typeof VALID_CONTENT_TYPES[number];
+
+export async function GET(request: NextRequest) {
+  try {
+    const searchParams = request.nextUrl.searchParams;
+    const query = searchParams.get('q');
+    const type = searchParams.get('type') as SearchType | null;
+    const contentType = searchParams.get('contentType') as ContentType | null;
+    const limitParam = searchParams.get('limit');
+    const tagsParam = searchParams.get('tags');
+
+    // クエリパラメータのバリデーション
+    if (!query || query.trim().length === 0) {
+      return NextResponse.json(
+        { error: '検索クエリは必須です' },
+        { status: 400 }
+      );
+    }
+
+    // クエリの長さ制限
+    if (query.length > 200) {
+      return NextResponse.json(
+        { error: '検索クエリは200文字以内にしてください' },
+        { status: 400 }
+      );
+    }
+
+    // 検索タイプのバリデーション
+    const searchType: SearchType = type && VALID_SEARCH_TYPES.includes(type) 
+      ? type 
+      : 'hybrid';
+
+    // コンテンツタイプのバリデーション
+    const validatedContentType: ContentType = contentType && VALID_CONTENT_TYPES.includes(contentType)
+      ? contentType
+      : 'all';
+
+    // 件数のバリデーション
+    const limit = limitParam ? Math.min(Math.max(1, parseInt(limitParam, 10)), 50) : 20;
+
+    // タグのパース
+    const tags = tagsParam ? tagsParam.split(',').map(t => t.trim()).filter(t => t.length > 0) : undefined;
+
+    // 検索オプション
+    const options: SearchOptions = {
+      limit,
+      contentType: validatedContentType === 'all' ? 'all' : validatedContentType,
+      tags,
+    };
+
+    // 検索実行
+    let results;
+    switch (searchType) {
+      case 'fulltext':
+        results = await search(query, options);
+        break;
+      case 'vector':
+        results = await vectorSearch(query, options);
+        break;
+      case 'hybrid':
+      default:
+        results = await hybridSearch(query, options);
+        break;
+    }
+
+    // レスポンスの整形（contentは長いので短縮）
+    const formattedResults = results.map(result => ({
+      id: result.id,
+      type: result.type,
+      title: result.title,
+      tags: result.tags,
+      author: result.author,
+      url: result.url,
+      createdAt: result.createdAt,
+      score: result.score,
+      // contentは最初の200文字のみ返す
+      snippet: result.content.slice(0, 200) + (result.content.length > 200 ? '...' : ''),
+    }));
+
+    return NextResponse.json({
+      query,
+      searchType,
+      contentType: validatedContentType,
+      total: formattedResults.length,
+      results: formattedResults,
+    });
+
+  } catch (error) {
+    console.error('Search error:', error);
+    return NextResponse.json(
+      { error: '検索中にエラーが発生しました' },
+      { status: 500 }
+    );
+  }
+}
+

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -20,6 +20,7 @@ import { AuthDialog } from "@/components/auth-dialog"
 import ConsentManager from "@/components/ConsentManager"
 import { PWAInstallPrompt } from "@/components/pwa-install-prompt"
 import { NotificationHandler } from "@/components/actions/notification-handler"
+import { SearchDialogProvider, SearchDialog } from "@/components/search/search-command"
 
 export const metadata: Metadata = {
   title: "Datatech Learning Place",
@@ -80,8 +81,10 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           disableTransitionOnChange
         >
           <NextTopLoader color="#1d4ed8" />
+          <SearchDialogProvider>
           <SidebarProvider defaultOpen={defaultOpen}>
             <AppSidebar />
+            <SearchDialog />
             <div className="flex flex-col min-h-screen w-screen">
               <main className="flex-1">
                 {/* スマホ対応の固定ヘッダー */}
@@ -113,6 +116,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
               <Footer />
             </div>
           </SidebarProvider>
+          </SearchDialogProvider>
           <PWAInstallPrompt />
           <NotificationHandler />
         </ThemeProvider>

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -147,7 +147,7 @@ export function AppSidebar() {
           </SidebarMenuItem>
           <SidebarMenuItem className="hidden group-data-[collapsible=icon]:flex justify-center">
             <SidebarMenuButton asChild className="w-8 h-8 p-0 mt-4">
-              <button onClick={handleOpenSearch}>
+              <button onClick={handleOpenSearch} aria-label="検索を開く">
                 <Search className="h-4 w-4" />
               </button>
             </SidebarMenuButton>

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -13,7 +13,10 @@ import {
   LogOut,
   ChevronLeft,
   Bell,
+  Search,
 } from "lucide-react"
+
+import { SearchCommand } from "@/components/search/search-command"
 
 import {
   Sidebar,
@@ -137,6 +140,16 @@ export function AppSidebar() {
               </span>
             </Link>
             <ChevronLeft className="w-10 group-data-[collapsible=icon]:hidden cursor-pointer" onClick={() => toggleSidebar()} />
+          </SidebarMenuItem>
+          <SidebarMenuItem className="group-data-[collapsible=icon]:hidden">
+            <SearchCommand />
+          </SidebarMenuItem>
+          <SidebarMenuItem className="hidden group-data-[collapsible=icon]:flex justify-center">
+            <SidebarMenuButton asChild className="w-8 h-8 p-0 mt-4">
+              <button onClick={() => document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', metaKey: true }))}>
+                <Search className="h-4 w-4" />
+              </button>
+            </SidebarMenuButton>
           </SidebarMenuItem>
         </SidebarMenu>
       </SidebarHeader>

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -16,7 +16,7 @@ import {
   Search,
 } from "lucide-react"
 
-import { SearchCommand } from "@/components/search/search-command"
+import { SearchCommand, useSearchDialog } from "@/components/search/search-command"
 
 import {
   Sidebar,
@@ -99,6 +99,7 @@ export function AppSidebar() {
   const pathname = usePathname()
   const { toggleSidebar } = useSidebar()
   const { user, error, isLoading } = useUser();
+  const { handleOpenSearch } = useSearchDialog();
 
   // 画面サイズが小さい時のみサイドバーを閉じる関数
   const handleLinkClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
@@ -146,7 +147,7 @@ export function AppSidebar() {
           </SidebarMenuItem>
           <SidebarMenuItem className="hidden group-data-[collapsible=icon]:flex justify-center">
             <SidebarMenuButton asChild className="w-8 h-8 p-0 mt-4">
-              <button onClick={() => document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', metaKey: true }))}>
+              <button onClick={handleOpenSearch}>
                 <Search className="h-4 w-4" />
               </button>
             </SidebarMenuButton>

--- a/components/auth-dialog.tsx
+++ b/components/auth-dialog.tsx
@@ -68,14 +68,14 @@ export function AuthDialog() {
     return (
       <Dialog open={open} onOpenChange={handleDialogClose}>
         <DialogContent>
-          <DialogHeader>
+          <DialogHeader className="mx-2">
             <DialogTitle>学習状況を記録しよう</DialogTitle>
             <DialogDescription>
               クイズの解答状況などの学習状況を記録するにはサインインが必要です。<br />
               <Link href="/global/privacy" onClick={() => handleDialogClose(false)} className="underline text-blue-500">プライバシーポリシーはこちら</Link>
             </DialogDescription>
           </DialogHeader>
-          <Button asChild>
+          <Button asChild className="mx-2">
             <a href={`/api/auth/login?returnTo=${pathname}`} onClick={handleLoginClick}>サインイン（無料）</a>
           </Button>
         </DialogContent>

--- a/components/search/search-command.tsx
+++ b/components/search/search-command.tsx
@@ -122,6 +122,8 @@ export function SearchDialog() {
   // 検索のデバウンス（AbortControllerでin-flightリクエストをキャンセル）
   React.useEffect(() => {
     if (!query.trim()) {
+      // リクエストIDをインクリメントして、in-flightリクエストのコールバックを無効化
+      searchRequestIdRef.current++
       setResults([])
       setHasSearched(false)
       setIsLoading(false) // クエリが空の場合はローディング状態を解除

--- a/components/search/search-command.tsx
+++ b/components/search/search-command.tsx
@@ -122,6 +122,7 @@ export function SearchDialog() {
     if (!query.trim()) {
       setResults([])
       setHasSearched(false)
+      setIsLoading(false) // クエリが空の場合はローディング状態を解除
       return
     }
 
@@ -151,10 +152,13 @@ export function SearchDialog() {
         setResults([])
         console.error("Search error:", error)
       } finally {
-        // キャンセルされた場合はローディング状態を更新しない
+        // キャンセルされた場合もローディング状態を解除（新しい検索が開始される場合はsetIsLoading(true)が呼ばれる）
         if (!abortController.signal.aborted) {
           setIsLoading(false)
           setHasSearched(true)
+        } else {
+          // 中断された場合もローディング状態を解除
+          setIsLoading(false)
         }
       }
     }, 300) // 300ms デバウンス
@@ -162,6 +166,8 @@ export function SearchDialog() {
     return () => {
       clearTimeout(timer)
       abortController.abort()
+      // クリーンアップ時にローディング状態を解除（タイマーがクリアされた場合）
+      setIsLoading(false)
     }
   }, [query])
 

--- a/components/search/search-command.tsx
+++ b/components/search/search-command.tsx
@@ -1,0 +1,222 @@
+"use client"
+
+import * as React from "react"
+import { useRouter } from "next/navigation"
+import { Search, FileQuestion, BookOpen, Loader2, Tag } from "lucide-react"
+
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@/components/ui/command"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+
+// 検索結果の型
+interface SearchResult {
+  id: string
+  type: 'quiz' | 'text'
+  title: string
+  tags: string[]
+  author: string
+  url: string
+  createdAt: string
+  score: number
+  snippet: string
+}
+
+interface SearchResponse {
+  query: string
+  searchType: string
+  contentType: string
+  total: number
+  results: SearchResult[]
+}
+
+export function SearchCommand() {
+  const router = useRouter()
+  const [open, setOpen] = React.useState(false)
+  const [query, setQuery] = React.useState("")
+  const [results, setResults] = React.useState<SearchResult[]>([])
+  const [isLoading, setIsLoading] = React.useState(false)
+  const [hasSearched, setHasSearched] = React.useState(false)
+
+  // キーボードショートカット (Cmd+K / Ctrl+K)
+  React.useEffect(() => {
+    const down = (e: KeyboardEvent) => {
+      if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault()
+        setOpen((open) => !open)
+      }
+    }
+    document.addEventListener("keydown", down)
+    return () => document.removeEventListener("keydown", down)
+  }, [])
+
+  // 検索のデバウンス
+  React.useEffect(() => {
+    if (!query.trim()) {
+      setResults([])
+      setHasSearched(false)
+      return
+    }
+
+    const timer = setTimeout(async () => {
+      setIsLoading(true)
+      try {
+        const response = await fetch(
+          `/api/search?q=${encodeURIComponent(query)}&type=hybrid&limit=20`
+        )
+        if (response.ok) {
+          const data: SearchResponse = await response.json()
+          setResults(data.results)
+          setHasSearched(true)
+        }
+      } catch (error) {
+        console.error("Search error:", error)
+      } finally {
+        setIsLoading(false)
+      }
+    }, 300) // 300ms デバウンス
+
+    return () => clearTimeout(timer)
+  }, [query])
+
+  // 結果選択時の処理
+  const handleSelect = (url: string) => {
+    setOpen(false)
+    setQuery("")
+    setResults([])
+    setHasSearched(false)
+    router.push(url)
+  }
+
+  // ダイアログが閉じられた時のリセット
+  const handleOpenChange = (open: boolean) => {
+    setOpen(open)
+    if (!open) {
+      setQuery("")
+      setResults([])
+      setHasSearched(false)
+    }
+  }
+
+  // クイズとテキストの結果を分類
+  const quizResults = results.filter(r => r.type === 'quiz')
+  const textResults = results.filter(r => r.type === 'text')
+
+  return (
+    <>
+      <Button
+        variant="outline"
+        className="relative h-9 w-full justify-start rounded-md bg-muted/50 text-sm font-normal text-muted-foreground shadow-none sm:pr-12 lg:w-60 mt-4 mb-0"
+        onClick={() => setOpen(true)}
+      >
+        <Search className="mr-2 h-4 w-4" />
+        <span className="hidden lg:inline-flex">検索...</span>
+        <span className="inline-flex lg:hidden">検索</span>
+        <kbd className="pointer-events-none absolute right-1.5 top-1.5 hidden h-6 select-none items-center gap-1 rounded border bg-background px-1.5 font-mono text-xs font-medium opacity-100 sm:flex">
+          <span className="text-xs">⌘</span>K
+        </kbd>
+      </Button>
+
+      <CommandDialog open={open} onOpenChange={handleOpenChange}>
+        <CommandInput
+          placeholder="クイズやテキストを検索..."
+          value={query}
+          onValueChange={setQuery}
+        />
+        <CommandList className="max-h-[400px]">
+          {isLoading ? (
+            <div className="flex items-center justify-center py-6">
+              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+              <span className="ml-2 text-sm text-muted-foreground">検索中...</span>
+            </div>
+          ) : hasSearched && results.length === 0 ? (
+            <CommandEmpty>
+              「{query}」に一致する結果が見つかりませんでした
+            </CommandEmpty>
+          ) : (
+            <>
+              {quizResults.length > 0 && (
+                <CommandGroup heading="クイズ">
+                  {quizResults.map((result) => (
+                    <CommandItem
+                      key={result.id}
+                      value={result.id}
+                      onSelect={() => handleSelect(result.url)}
+                      className="flex flex-col items-start gap-1 py-3"
+                    >
+                      <div className="flex w-full items-center gap-2">
+                        <FileQuestion className="h-4 w-4 shrink-0 text-blue-500" />
+                        <span className="font-medium truncate flex-1">{result.title}</span>
+                        <span className="text-xs text-muted-foreground shrink-0">
+                          {result.createdAt}
+                        </span>
+                      </div>
+                      {result.tags.length > 0 && (
+                        <div className="flex items-center gap-1 ml-6 flex-wrap">
+                          <Tag className="h-3 w-3 text-muted-foreground" />
+                          {result.tags.slice(0, 3).map((tag) => (
+                            <Badge key={tag} variant="secondary" className="text-xs py-0 px-1">
+                              {tag}
+                            </Badge>
+                          ))}
+                          {result.tags.length > 3 && (
+                            <span className="text-xs text-muted-foreground">
+                              +{result.tags.length - 3}
+                            </span>
+                          )}
+                        </div>
+                      )}
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              )}
+
+              {quizResults.length > 0 && textResults.length > 0 && (
+                <CommandSeparator />
+              )}
+
+              {textResults.length > 0 && (
+                <CommandGroup heading="テキスト">
+                  {textResults.map((result) => (
+                    <CommandItem
+                      key={result.id}
+                      value={result.id}
+                      onSelect={() => handleSelect(result.url)}
+                      className="flex flex-col items-start gap-1 py-3"
+                    >
+                      <div className="flex w-full items-center gap-2">
+                        <BookOpen className="h-4 w-4 shrink-0 text-green-500" />
+                        <span className="font-medium truncate flex-1">{result.title}</span>
+                      </div>
+                      {result.snippet && (
+                        <p className="text-xs text-muted-foreground ml-6 line-clamp-2">
+                          {result.snippet}
+                        </p>
+                      )}
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              )}
+
+              {!hasSearched && !query && (
+                <div className="py-6 text-center text-sm text-muted-foreground">
+                  <Search className="mx-auto h-8 w-8 mb-2 opacity-50" />
+                  <p>キーワードを入力して検索</p>
+                  <p className="text-xs mt-1">ハイブリッド検索でクイズとテキストを検索できます</p>
+                </div>
+              )}
+            </>
+          )}
+        </CommandList>
+      </CommandDialog>
+    </>
+  )
+}
+

--- a/components/search/search-command.tsx
+++ b/components/search/search-command.tsx
@@ -74,12 +74,18 @@ export function SearchCommand() {
         if (response.ok) {
           const data: SearchResponse = await response.json()
           setResults(data.results)
-          setHasSearched(true)
+        } else {
+          // エラー時は結果をクリア
+          setResults([])
+          console.error("Search API error:", response.status, response.statusText)
         }
       } catch (error) {
+        // ネットワークエラー時も結果をクリア
+        setResults([])
         console.error("Search error:", error)
       } finally {
         setIsLoading(false)
+        setHasSearched(true)
       }
     }, 300) // 300ms デバウンス
 
@@ -219,4 +225,5 @@ export function SearchCommand() {
     </>
   )
 }
+
 

--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -6,7 +6,8 @@ import { Command as CommandPrimitive } from "cmdk"
 import { Search } from "lucide-react"
 
 import { cn } from "@/lib/utils"
-import { Dialog, DialogContent } from "@/components/ui/dialog"
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog"
+import * as VisuallyHidden from "@radix-ui/react-visually-hidden"
 
 const Command = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive>,
@@ -23,11 +24,18 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-const CommandDialog = ({ children, ...props }: DialogProps) => {
+interface CommandDialogProps extends DialogProps {
+  title?: string;
+}
+
+const CommandDialog = ({ children, title = "検索", ...props }: CommandDialogProps) => {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0 shadow-lg">
-        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+        <VisuallyHidden.Root>
+          <DialogTitle>{title}</DialogTitle>
+        </VisuallyHidden.Root>
+        <Command shouldFilter={false} className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>
       </DialogContent>

--- a/lib/search/embedder.ts
+++ b/lib/search/embedder.ts
@@ -1,0 +1,113 @@
+import { pipeline, type FeatureExtractionPipeline } from '@xenova/transformers';
+
+// Embeddingパイプラインのシングルトンインスタンス
+let embeddingPipeline: FeatureExtractionPipeline | null = null;
+let embeddingPromise: Promise<FeatureExtractionPipeline> | null = null;
+
+// 使用するモデル（多言語対応、軽量）
+const MODEL_NAME = 'Xenova/multilingual-e5-small';
+
+/**
+ * Embeddingパイプラインを初期化する（シングルトン）
+ */
+export async function getEmbeddingPipeline(): Promise<FeatureExtractionPipeline> {
+  if (embeddingPipeline) {
+    return embeddingPipeline;
+  }
+
+  if (embeddingPromise) {
+    return embeddingPromise;
+  }
+
+  console.log(`Loading embedding model: ${MODEL_NAME}...`);
+  
+  embeddingPromise = pipeline('feature-extraction', MODEL_NAME, {
+    // キャッシュディレクトリを指定
+    cache_dir: './.cache/transformers',
+  }).then((p) => {
+    embeddingPipeline = p;
+    console.log('Embedding model loaded successfully');
+    return p;
+  }).catch((err) => {
+    embeddingPromise = null;
+    throw err;
+  });
+
+  return embeddingPromise;
+}
+
+/**
+ * テキストからembeddingベクトルを生成する
+ * @param text 入力テキスト
+ * @returns embedding ベクトル（Float32Array）
+ */
+export async function generateEmbedding(text: string): Promise<number[]> {
+  const pipe = await getEmbeddingPipeline();
+  
+  // E5モデルは"query: "または"passage: "プレフィックスを推奨
+  // 検索クエリには"query: "、ドキュメントには"passage: "を使用
+  const prefixedText = `passage: ${text}`;
+  
+  const output = await pipe(prefixedText, {
+    pooling: 'mean',
+    normalize: true,
+  });
+
+  // Tensorからnumber[]に変換
+  return Array.from(output.data as Float32Array);
+}
+
+/**
+ * 検索クエリ用のembeddingを生成する
+ * @param query 検索クエリ
+ * @returns embedding ベクトル
+ */
+export async function generateQueryEmbedding(query: string): Promise<number[]> {
+  const pipe = await getEmbeddingPipeline();
+  
+  // E5モデルのクエリプレフィックス
+  const prefixedQuery = `query: ${query}`;
+  
+  const output = await pipe(prefixedQuery, {
+    pooling: 'mean',
+    normalize: true,
+  });
+
+  return Array.from(output.data as Float32Array);
+}
+
+/**
+ * 複数テキストのembeddingを一括生成する
+ * @param texts テキストの配列
+ * @returns embedding ベクトルの配列
+ */
+export async function generateEmbeddings(texts: string[]): Promise<number[][]> {
+  const results: number[][] = [];
+  
+  // バッチ処理（メモリ効率のため少しずつ処理）
+  const batchSize = 10;
+  
+  for (let i = 0; i < texts.length; i += batchSize) {
+    const batch = texts.slice(i, i + batchSize);
+    const batchResults = await Promise.all(
+      batch.map(text => generateEmbedding(text))
+    );
+    results.push(...batchResults);
+    
+    // 進捗表示
+    if ((i + batchSize) % 50 === 0 || i + batchSize >= texts.length) {
+      console.log(`Embedding progress: ${Math.min(i + batchSize, texts.length)}/${texts.length}`);
+    }
+  }
+  
+  return results;
+}
+
+/**
+ * embeddingの次元数を取得する
+ */
+export function getEmbeddingDimension(): number {
+  // multilingual-e5-smallの次元数
+  return 384;
+}
+

--- a/lib/search/embedder.ts
+++ b/lib/search/embedder.ts
@@ -21,9 +21,12 @@ export async function getEmbeddingPipeline(): Promise<FeatureExtractionPipeline>
 
   console.log(`Loading embedding model: ${MODEL_NAME}...`);
   
+  // キャッシュディレクトリを決定（環境変数優先、Docker実行時は書き込み可能なディレクトリを使用）
+  const cacheDir = process.env.TRANSFORMERS_CACHE || './.cache/transformers';
+  
   embeddingPromise = pipeline('feature-extraction', MODEL_NAME, {
     // キャッシュディレクトリを指定
-    cache_dir: './.cache/transformers',
+    cache_dir: cacheDir,
   }).then((p) => {
     embeddingPipeline = p;
     console.log('Embedding model loaded successfully');
@@ -110,4 +113,5 @@ export function getEmbeddingDimension(): number {
   // multilingual-e5-smallの次元数
   return 384;
 }
+
 

--- a/lib/search/embedder.ts
+++ b/lib/search/embedder.ts
@@ -113,5 +113,3 @@ export function getEmbeddingDimension(): number {
   // multilingual-e5-smallの次元数
   return 384;
 }
-
-

--- a/lib/search/index.ts
+++ b/lib/search/index.ts
@@ -10,8 +10,11 @@ export {
 export { 
   getSearchClient, 
   search, 
+  vectorSearch,
   hybridSearch,
   type SearchResult,
-  type SearchOptions 
+  type SearchOptions,
+  type SearchResponse
 } from './orama-client';
+
 

--- a/lib/search/index.ts
+++ b/lib/search/index.ts
@@ -1,0 +1,17 @@
+// 検索モジュールのエクスポート
+export { getTokenizer, tokenize, extractUniqueTokens, createOramaTokenizer } from './tokenizer';
+export { 
+  getEmbeddingPipeline, 
+  generateEmbedding, 
+  generateQueryEmbedding, 
+  generateEmbeddings,
+  getEmbeddingDimension 
+} from './embedder';
+export { 
+  getSearchClient, 
+  search, 
+  hybridSearch,
+  type SearchResult,
+  type SearchOptions 
+} from './orama-client';
+

--- a/lib/search/orama-client.ts
+++ b/lib/search/orama-client.ts
@@ -319,10 +319,13 @@ export async function hybridSearch(
   const sortedResults = Array.from(resultMap.values())
     .sort((a, b) => b.combinedScore - a.combinedScore);
 
-  // combinedScoreをscoreとして返す
+  // combinedScoreを正規化してscoreとして返す
+  // これにより、片方の検索のみで見つかった結果も適切にスコアリングされる
+  // （例：全文検索のみの結果でも最大スコアが1.0になりうる）
+  const maxCombinedScore = Math.max(...sortedResults.map(r => r.combinedScore), 0.001);
   const scoredResults = sortedResults.map(({ combinedScore, ...rest }) => ({
     ...rest,
-    score: combinedScore,
+    score: combinedScore / maxCombinedScore,
   }));
 
   // 最小スコア閾値でフィルタリング（limitの前に適用）

--- a/lib/search/orama-client.ts
+++ b/lib/search/orama-client.ts
@@ -2,6 +2,7 @@ import { create, load, search as oramaSearch } from '@orama/orama';
 import fs from 'fs';
 import path from 'path';
 import { generateQueryEmbedding, getEmbeddingDimension } from './embedder';
+import { getTokenizer, createOramaTokenizer } from './tokenizer';
 
 // 検索結果の型
 export interface SearchResult {
@@ -70,6 +71,9 @@ export async function getSearchClient() {
  * データベースをロードする
  */
 async function loadDatabase() {
+  // トークナイザーを初期化（日本語トークナイザーを使用するため）
+  await getTokenizer();
+
   const indexPath = path.join(process.cwd(), 'data', 'search-index.json');
 
   // インデックスファイルが存在しない場合は空のDBを作成
@@ -77,6 +81,9 @@ async function loadDatabase() {
     console.warn('Search index not found. Creating empty database.');
     return create({
       schema: SEARCH_SCHEMA,
+      components: {
+        tokenizer: createOramaTokenizer(),
+      },
     });
   }
 
@@ -86,6 +93,9 @@ async function loadDatabase() {
   // スキーマを定義してDBを作成
   const db = await create({
     schema: SEARCH_SCHEMA,
+    components: {
+      tokenizer: createOramaTokenizer(),
+    },
   });
 
   // 保存したデータをロード

--- a/lib/search/orama-client.ts
+++ b/lib/search/orama-client.ts
@@ -150,7 +150,7 @@ export async function vectorSearch(
   query: string,
   options: SearchOptions = {}
 ): Promise<SearchResult[]> {
-  const { limit = 20, contentType = 'all' } = options;
+  const { limit = 20, contentType = 'all', tags } = options;
   const db = await getSearchClient();
 
   // クエリのembeddingを生成
@@ -161,6 +161,9 @@ export async function vectorSearch(
   const where: Record<string, any> = {};
   if (contentType !== 'all') {
     where.type = contentType;
+  }
+  if (tags && tags.length > 0) {
+    where.tags = { containsAll: tags };
   }
 
   // Orama v3ではsearchにmodeを指定してベクター検索

--- a/lib/search/orama-client.ts
+++ b/lib/search/orama-client.ts
@@ -188,7 +188,9 @@ export async function search(
 
   // スコアを正規化してminScoreでフィルタリング
   if (minScore !== undefined && mappedResults.length > 0) {
-    const maxScore = Math.max(...mappedResults.map(r => r.score), 1);
+    // 結果内の最大スコアで正規化（最高スコアが1.0になる）
+    // フォールバックの1は全スコアが0の場合のみ使用（0除算防止）
+    const maxScore = Math.max(...mappedResults.map(r => r.score)) || 1;
     mappedResults = mappedResults
       .map(r => ({ ...r, score: r.score / maxScore }))
       .filter(r => r.score >= minScore);
@@ -250,7 +252,9 @@ export async function vectorSearch(
 
   // スコアを正規化してminScoreでフィルタリング
   if (minScore !== undefined && mappedResults.length > 0) {
-    const maxScore = Math.max(...mappedResults.map(r => r.score), 1);
+    // 結果内の最大スコアで正規化（最高スコアが1.0になる）
+    // フォールバックの1は全スコアが0の場合のみ使用（0除算防止）
+    const maxScore = Math.max(...mappedResults.map(r => r.score)) || 1;
     mappedResults = mappedResults
       .map(r => ({ ...r, score: r.score / maxScore }))
       .filter(r => r.score >= minScore);
@@ -290,7 +294,8 @@ export async function hybridSearch(
   const resultMap = new Map<string, SearchResult & { combinedScore: number }>();
 
   // 全文検索結果を追加（重み: 0.4）
-  const maxFulltextScore = Math.max(...fulltextResults.map(r => r.score), 1);
+  // 結果内の最大スコアで正規化（フォールバックの1は結果が空または全スコア0の場合のみ）
+  const maxFulltextScore = Math.max(...fulltextResults.map(r => r.score)) || 1;
   for (const result of fulltextResults) {
     const normalizedScore = result.score / maxFulltextScore;
     resultMap.set(result.id, {
@@ -300,7 +305,8 @@ export async function hybridSearch(
   }
 
   // ベクター検索結果を追加/マージ（重み: 0.6）
-  const maxVectorScore = Math.max(...vectorResults.map(r => r.score), 1);
+  // 結果内の最大スコアで正規化（フォールバックの1は結果が空または全スコア0の場合のみ）
+  const maxVectorScore = Math.max(...vectorResults.map(r => r.score)) || 1;
   for (const result of vectorResults) {
     const normalizedScore = result.score / maxVectorScore;
     const existing = resultMap.get(result.id);

--- a/lib/search/orama-client.ts
+++ b/lib/search/orama-client.ts
@@ -1,0 +1,236 @@
+import { create, load, search as oramaSearch } from '@orama/orama';
+import fs from 'fs';
+import path from 'path';
+import { generateQueryEmbedding, getEmbeddingDimension } from './embedder';
+
+// 検索結果の型
+export interface SearchResult {
+  id: string;
+  type: 'quiz' | 'text';
+  title: string;
+  content: string;
+  tags: string[];
+  author: string;
+  url: string;
+  createdAt: string;
+  score: number;
+}
+
+// 検索オプション
+export interface SearchOptions {
+  type?: 'hybrid' | 'fulltext' | 'vector';
+  limit?: number;
+  contentType?: 'quiz' | 'text' | 'all';
+  tags?: string[];
+}
+
+// スキーマ定義
+const SEARCH_SCHEMA = {
+  id: 'string' as const,
+  type: 'string' as const,
+  title: 'string' as const,
+  content: 'string' as const,
+  tags: 'string[]' as const,
+  author: 'string' as const,
+  url: 'string' as const,
+  createdAt: 'string' as const,
+  embedding: `vector[${getEmbeddingDimension()}]` as const,
+};
+
+// Oramaデータベースインスタンス（シングルトン）
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let dbInstance: any = null;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let dbPromise: Promise<any> | null = null;
+
+/**
+ * 検索クライアントを取得する（シングルトン）
+ */
+export async function getSearchClient() {
+  if (dbInstance) {
+    return dbInstance;
+  }
+
+  if (dbPromise) {
+    return dbPromise;
+  }
+
+  dbPromise = loadDatabase().then((db) => {
+    dbInstance = db;
+    return db;
+  }).catch((err) => {
+    dbPromise = null;
+    throw err;
+  });
+
+  return dbPromise;
+}
+
+/**
+ * データベースをロードする
+ */
+async function loadDatabase() {
+  const indexPath = path.join(process.cwd(), 'data', 'search-index.json');
+
+  // インデックスファイルが存在しない場合は空のDBを作成
+  if (!fs.existsSync(indexPath)) {
+    console.warn('Search index not found. Creating empty database.');
+    return create({
+      schema: SEARCH_SCHEMA,
+    });
+  }
+
+  console.log('Loading search index...');
+  const serialized = JSON.parse(fs.readFileSync(indexPath, 'utf-8'));
+
+  // スキーマを定義してDBを作成
+  const db = await create({
+    schema: SEARCH_SCHEMA,
+  });
+
+  // 保存したデータをロード
+  await load(db, serialized);
+  console.log('Search index loaded successfully');
+
+  return db;
+}
+
+/**
+ * 検索結果をSearchResult型に変換
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function mapHitToResult(hit: any): SearchResult {
+  return {
+    id: String(hit.document.id || ''),
+    type: hit.document.type as 'quiz' | 'text',
+    title: String(hit.document.title || ''),
+    content: String(hit.document.content || ''),
+    tags: Array.isArray(hit.document.tags) ? hit.document.tags : [],
+    author: String(hit.document.author || ''),
+    url: String(hit.document.url || ''),
+    createdAt: String(hit.document.createdAt || ''),
+    score: hit.score,
+  };
+}
+
+/**
+ * 全文検索を実行
+ */
+export async function search(
+  query: string,
+  options: SearchOptions = {}
+): Promise<SearchResult[]> {
+  const { limit = 20, contentType = 'all', tags } = options;
+  const db = await getSearchClient();
+
+  // フィルター条件を構築
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const where: Record<string, any> = {};
+  if (contentType !== 'all') {
+    where.type = contentType;
+  }
+  if (tags && tags.length > 0) {
+    where.tags = { containsAll: tags };
+  }
+
+  const results = await oramaSearch(db, {
+    term: query,
+    properties: ['title', 'content', 'tags'],
+    limit,
+    where: Object.keys(where).length > 0 ? where : undefined,
+  });
+
+  return results.hits.map(mapHitToResult);
+}
+
+/**
+ * ベクター検索を実行
+ */
+export async function vectorSearch(
+  query: string,
+  options: SearchOptions = {}
+): Promise<SearchResult[]> {
+  const { limit = 20, contentType = 'all' } = options;
+  const db = await getSearchClient();
+
+  // クエリのembeddingを生成
+  const queryEmbedding = await generateQueryEmbedding(query);
+
+  // フィルター条件を構築
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const where: Record<string, any> = {};
+  if (contentType !== 'all') {
+    where.type = contentType;
+  }
+
+  // Orama v3ではsearchにmodeを指定してベクター検索
+  const results = await oramaSearch(db, {
+    mode: 'vector',
+    vector: {
+      value: queryEmbedding,
+      property: 'embedding',
+    },
+    limit,
+    where: Object.keys(where).length > 0 ? where : undefined,
+    includeVectors: false,
+  });
+
+  return results.hits.map(mapHitToResult);
+}
+
+/**
+ * ハイブリッド検索を実行（全文検索 + ベクター検索）
+ */
+export async function hybridSearch(
+  query: string,
+  options: SearchOptions = {}
+): Promise<SearchResult[]> {
+  const { limit = 20 } = options;
+
+  // 全文検索とベクター検索を並列実行
+  const [fulltextResults, vectorResults] = await Promise.all([
+    search(query, { ...options, limit: limit * 2 }),
+    vectorSearch(query, { ...options, limit: limit * 2 }),
+  ]);
+
+  // スコアを正規化してマージ
+  const resultMap = new Map<string, SearchResult & { combinedScore: number }>();
+
+  // 全文検索結果を追加（重み: 0.4）
+  const maxFulltextScore = Math.max(...fulltextResults.map(r => r.score), 1);
+  for (const result of fulltextResults) {
+    const normalizedScore = result.score / maxFulltextScore;
+    resultMap.set(result.id, {
+      ...result,
+      combinedScore: normalizedScore * 0.4,
+    });
+  }
+
+  // ベクター検索結果を追加/マージ（重み: 0.6）
+  const maxVectorScore = Math.max(...vectorResults.map(r => r.score), 1);
+  for (const result of vectorResults) {
+    const normalizedScore = result.score / maxVectorScore;
+    const existing = resultMap.get(result.id);
+    
+    if (existing) {
+      existing.combinedScore += normalizedScore * 0.6;
+    } else {
+      resultMap.set(result.id, {
+        ...result,
+        combinedScore: normalizedScore * 0.6,
+      });
+    }
+  }
+
+  // スコアでソートして上位を返す
+  const sortedResults = Array.from(resultMap.values())
+    .sort((a, b) => b.combinedScore - a.combinedScore)
+    .slice(0, limit);
+
+  // combinedScoreをscoreとして返す
+  return sortedResults.map(({ combinedScore, ...rest }) => ({
+    ...rest,
+    score: combinedScore,
+  }));
+}
+

--- a/lib/search/tokenizer.ts
+++ b/lib/search/tokenizer.ts
@@ -131,3 +131,4 @@ export function createOramaTokenizer() {
   };
 }
 
+

--- a/lib/search/tokenizer.ts
+++ b/lib/search/tokenizer.ts
@@ -1,0 +1,133 @@
+import kuromoji from 'kuromoji';
+import path from 'path';
+
+// kuromojiのトークナイザーインスタンス（シングルトン）
+let tokenizerInstance: kuromoji.Tokenizer<kuromoji.IpadicFeatures> | null = null;
+let tokenizerPromise: Promise<kuromoji.Tokenizer<kuromoji.IpadicFeatures>> | null = null;
+
+/**
+ * kuromojiトークナイザーを初期化する（シングルトン）
+ */
+export async function getTokenizer(): Promise<kuromoji.Tokenizer<kuromoji.IpadicFeatures>> {
+  if (tokenizerInstance) {
+    return tokenizerInstance;
+  }
+
+  if (tokenizerPromise) {
+    return tokenizerPromise;
+  }
+
+  tokenizerPromise = new Promise((resolve, reject) => {
+    // node_modules内の辞書パスを取得
+    const dicPath = path.join(
+      process.cwd(),
+      'node_modules',
+      'kuromoji',
+      'dict'
+    );
+
+    kuromoji.builder({ dicPath }).build((err, tokenizer) => {
+      if (err) {
+        tokenizerPromise = null;
+        reject(err);
+        return;
+      }
+      tokenizerInstance = tokenizer;
+      resolve(tokenizer);
+    });
+  });
+
+  return tokenizerPromise;
+}
+
+/**
+ * 日本語テキストをトークン化する
+ * 名詞、動詞、形容詞、副詞を抽出
+ */
+export async function tokenize(text: string): Promise<string[]> {
+  const tokenizer = await getTokenizer();
+  const tokens = tokenizer.tokenize(text);
+
+  // 検索に有効な品詞のみを抽出
+  const validPosPatterns = [
+    '名詞',
+    '動詞',
+    '形容詞',
+    '副詞',
+  ];
+
+  const result: string[] = [];
+
+  for (const token of tokens) {
+    const pos = token.pos;
+    
+    // 有効な品詞かチェック
+    if (validPosPatterns.some(pattern => pos.startsWith(pattern))) {
+      // 基本形があれば基本形を使用、なければ表層形を使用
+      const term = token.basic_form !== '*' ? token.basic_form : token.surface_form;
+      
+      // 1文字以下の単語は除外（助詞などのノイズを減らす）
+      if (term.length > 1) {
+        result.push(term.toLowerCase());
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * テキストからユニークなトークンを抽出する
+ */
+export async function extractUniqueTokens(text: string): Promise<string[]> {
+  const tokens = await tokenize(text);
+  return [...new Set(tokens)];
+}
+
+/**
+ * Orama用のカスタムトークナイザー関数
+ * 同期的に呼び出す必要があるため、事前にtokenizerを初期化しておく必要がある
+ */
+export function createOramaTokenizer() {
+  if (!tokenizerInstance) {
+    throw new Error('Tokenizer not initialized. Call getTokenizer() first.');
+  }
+
+  return {
+    tokenize: (text: string): string[] => {
+      const tokens = tokenizerInstance!.tokenize(text);
+
+      const validPosPatterns = ['名詞', '動詞', '形容詞', '副詞'];
+      const result: string[] = [];
+
+      for (const token of tokens) {
+        const pos = token.pos;
+        if (validPosPatterns.some(pattern => pos.startsWith(pattern))) {
+          const term = token.basic_form !== '*' ? token.basic_form : token.surface_form;
+          if (term.length > 1) {
+            result.push(term.toLowerCase());
+          }
+        }
+      }
+
+      // 元のテキストも含める（完全一致検索用）
+      // N-gramも追加してより柔軟な検索を可能に
+      const normalized = text.toLowerCase().replace(/\s+/g, ' ').trim();
+      if (normalized.length > 0) {
+        result.push(normalized);
+        
+        // 2-gramを追加
+        for (let i = 0; i < normalized.length - 1; i++) {
+          const bigram = normalized.slice(i, i + 2);
+          if (bigram.trim().length === 2) {
+            result.push(bigram);
+          }
+        }
+      }
+
+      return [...new Set(result)];
+    },
+    language: 'japanese',
+  };
+}
+

--- a/lib/search/tokenizer.ts
+++ b/lib/search/tokenizer.ts
@@ -111,18 +111,9 @@ export function createOramaTokenizer() {
       }
 
       // 元のテキストも含める（完全一致検索用）
-      // N-gramも追加してより柔軟な検索を可能に
       const normalized = text.toLowerCase().replace(/\s+/g, ' ').trim();
       if (normalized.length > 0) {
         result.push(normalized);
-        
-        // 2-gramを追加
-        for (let i = 0; i < normalized.length - 1; i++) {
-          const bigram = normalized.slice(i, i + 2);
-          if (bigram.trim().length === 2) {
-            result.push(bigram);
-          }
-        }
       }
 
       return [...new Set(result)];
@@ -130,5 +121,3 @@ export function createOramaTokenizer() {
     language: 'japanese',
   };
 }
-
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@aws-sdk/lib-dynamodb": "^3.726.1",
         "@aws-sdk/util-dynamodb": "^3.726.1",
         "@next/third-parties": "15.5.9",
+        "@orama/orama": "^3.0.0",
         "@radix-ui/react-accordion": "^1.2.2",
         "@radix-ui/react-avatar": "^1.1.2",
         "@radix-ui/react-checkbox": "^1.1.3",
@@ -28,11 +29,14 @@
         "@radix-ui/react-slot": "^1.1.1",
         "@radix-ui/react-switch": "^1.1.2",
         "@radix-ui/react-tooltip": "^1.1.6",
+        "@radix-ui/react-visually-hidden": "^1.2.4",
         "@types/cheerio": "^0.22.35",
+        "@xenova/transformers": "^2.17.0",
         "cheerio": "^1.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
+        "kuromoji": "^0.1.2",
         "lucide-react": "^0.469.0",
         "next": "15.5.9",
         "next-pwa": "^5.6.0",
@@ -49,6 +53,7 @@
       },
       "devDependencies": {
         "@types/dompurify": "^3.0.5",
+        "@types/kuromoji": "^0.1.3",
         "@types/node": "^20",
         "@types/node-cron": "^3.0.11",
         "@types/react": "19.2.7",
@@ -59,6 +64,7 @@
         "postcss": "^8",
         "sharp": "^0.34.3",
         "tailwindcss": "^3.4.1",
+        "tsx": "^4.7.0",
         "typescript": "^5"
       }
     },
@@ -2355,6 +2361,422 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.1.tgz",
+      "integrity": "sha512-HHB50pdsBX6k47S4u5g/CaLjqS3qwaOVE5ILsq64jyzgMhLuCuZ8rGzM9yhsAjfjkbgUPMzZEPa7DAp7yz6vuA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.1.tgz",
+      "integrity": "sha512-kFqa6/UcaTbGm/NncN9kzVOODjhZW8e+FRdSeypWe6j33gzclHtwlANs26JrupOntlcWmB0u8+8HZo8s7thHvg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.1.tgz",
+      "integrity": "sha512-45fuKmAJpxnQWixOGCrS+ro4Uvb4Re9+UTieUY2f8AEc+t7d4AaZ6eUJ3Hva7dtrxAAWHtlEFsXFMAgNnGU9uQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.1.tgz",
+      "integrity": "sha512-LBEpOz0BsgMEeHgenf5aqmn/lLNTFXVfoWMUox8CtWWYK9X4jmQzWjoGoNb8lmAYml/tQ/Ysvm8q7szu7BoxRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.1.tgz",
+      "integrity": "sha512-veg7fL8eMSCVKL7IW4pxb54QERtedFDfY/ASrumK/SbFsXnRazxY4YykN/THYqFnFwJ0aVjiUrVG2PwcdAEqQQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.1.tgz",
+      "integrity": "sha512-+3ELd+nTzhfWb07Vol7EZ+5PTbJ/u74nC6iv4/lwIU99Ip5uuY6QoIf0Hn4m2HoV0qcnRivN3KSqc+FyCHjoVQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.1.tgz",
+      "integrity": "sha512-/8Rfgns4XD9XOSXlzUDepG8PX+AVWHliYlUkFI3K3GB6tqbdjYqdhcb4BKRd7C0BhZSoaCxhv8kTcBrcZWP+xg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.1.tgz",
+      "integrity": "sha512-GITpD8dK9C+r+5yRT/UKVT36h/DQLOHdwGVwwoHidlnA168oD3uxA878XloXebK4Ul3gDBBIvEdL7go9gCUFzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.1.tgz",
+      "integrity": "sha512-ieMID0JRZY/ZeCrsFQ3Y3NlHNCqIhTprJfDgSB3/lv5jJZ8FX3hqPyXWhe+gvS5ARMBJ242PM+VNz/ctNj//eA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.1.tgz",
+      "integrity": "sha512-W9//kCrh/6in9rWIBdKaMtuTTzNj6jSeG/haWBADqLLa9P8O5YSRDzgD5y9QBok4AYlzS6ARHifAb75V6G670Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.1.tgz",
+      "integrity": "sha512-VIUV4z8GD8rtSVMfAj1aXFahsi/+tcoXXNYmXgzISL+KB381vbSTNdeZHHHIYqFyXcoEhu9n5cT+05tRv13rlw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.1.tgz",
+      "integrity": "sha512-l4rfiiJRN7sTNI//ff65zJ9z8U+k6zcCg0LALU5iEWzY+a1mVZ8iWC1k5EsNKThZ7XCQ6YWtsZ8EWYm7r1UEsg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.1.tgz",
+      "integrity": "sha512-U0bEuAOLvO/DWFdygTHWY8C067FXz+UbzKgxYhXC0fDieFa0kDIra1FAhsAARRJbvEyso8aAqvPdNxzWuStBnA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.1.tgz",
+      "integrity": "sha512-NzdQ/Xwu6vPSf/GkdmRNsOfIeSGnh7muundsWItmBsVpMoNPVpM61qNzAVY3pZ1glzzAxLR40UyYM23eaDDbYQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.1.tgz",
+      "integrity": "sha512-7zlw8p3IApcsN7mFw0O1Z1PyEk6PlKMu18roImfl3iQHTnr/yAfYv6s4hXPidbDoI2Q0pW+5xeoM4eTCC0UdrQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.1.tgz",
+      "integrity": "sha512-cGj5wli+G+nkVQdZo3+7FDKC25Uh4ZVwOAK6A06Hsvgr8WqBBuOy/1s+PUEd/6Je+vjfm6stX0kmib5b/O2Ykw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.1.tgz",
+      "integrity": "sha512-z3H/HYI9MM0HTv3hQZ81f+AKb+yEoCRlUby1F80vbQ5XdzEMyY/9iNlAmhqiBKw4MJXwfgsh7ERGEOhrM1niMA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.1.tgz",
+      "integrity": "sha512-wzC24DxAvk8Em01YmVXyjl96Mr+ecTPyOuADAvjGg+fyBpGmxmcr2E5ttf7Im8D0sXZihpxzO1isus8MdjMCXQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.1.tgz",
+      "integrity": "sha512-1YQ8ybGi2yIXswu6eNzJsrYIGFpnlzEWRl6iR5gMgmsrR0FcNoV1m9k9sc3PuP5rUBLshOZylc9nqSgymI+TYg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.1.tgz",
+      "integrity": "sha512-5Z+DzLCrq5wmU7RDaMDe2DVXMRm2tTDvX2KU14JJVBN2CT/qov7XVix85QoJqHltpvAOZUAc3ndU56HSMWrv8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.1.tgz",
+      "integrity": "sha512-Q73ENzIdPF5jap4wqLtsfh8YbYSZ8Q0wnxplOlZUOyZy7B4ZKW8DXGWgTCZmF8VWD7Tciwv5F4NsRf6vYlZtqg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.1.tgz",
+      "integrity": "sha512-ajbHrGM/XiK+sXM0JzEbJAen+0E+JMQZ2l4RR4VFwvV9JEERx+oxtgkpoKv1SevhjavK2z2ReHk32pjzktWbGg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.1.tgz",
+      "integrity": "sha512-IPUW+y4VIjuDVn+OMzHc5FV4GubIwPnsz6ubkvN8cuhEqH81NovB53IUlrlBkPMEPxvNnf79MGBoz8rZ2iW8HA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.1.tgz",
+      "integrity": "sha512-RIVRWiljWA6CdVu8zkWcRmGP7iRRIIwvhDKem8UMBjPql2TXM5PkDVvvrzMtj1V+WFPB4K7zkIGM7VzRtFkjdg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.1.tgz",
+      "integrity": "sha512-2BR5M8CPbptC1AK5JbJT1fWrHLvejwZidKx3UMSF0ecHMa+smhi16drIrCEggkgviBwLYd5nwrFLSl5Kho96RQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.1.tgz",
+      "integrity": "sha512-d5X6RMYv6taIymSk8JBP+nxv8DQAMY6A51GPgusqLdK9wBz5wWIXy1KjTck6HnjE9hqJzJRdk+1p/t5soSbCtw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
@@ -2523,6 +2945,15 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
+    },
+    "node_modules/@huggingface/jinja": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.2.2.tgz",
+      "integrity": "sha512-/KPde26khDUIPkTGU82jdtTW9UAuvUTumCAbFs/7giR0SxsvZC4hru51PBvpijH6BVkHcROcvZM/lpy5h1jRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -3366,6 +3797,15 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@orama/orama": {
+      "version": "3.1.16",
+      "resolved": "https://registry.npmjs.org/@orama/orama/-/orama-3.1.16.tgz",
+      "integrity": "sha512-scSmQBD8eANlMUOglxHrN1JdSW8tDghsPuS83otqealBiIeMukCQMOf/wc0JJjDXomqwNdEQFLXLGHrU6PGxuA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20.0.0"
+      }
+    },
     "node_modules/@panva/hkdf": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
@@ -3374,6 +3814,70 @@
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
@@ -4289,6 +4793,29 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-separator": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.8.tgz",
@@ -4430,6 +4957,29 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -4589,12 +5139,35 @@
       }
     },
     "node_modules/@radix-ui/react-visually-hidden": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
-      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.4.tgz",
+      "integrity": "sha512-kaeiyGCe844dkb9AVF+rb4yTyb1LiLN/e3es3nLiRyN4dC8AduBYPMnnNlDjX2VDOcvDEiPnRNMJeWCfsX0txg==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.3"
+        "@radix-ui/react-primitive": "2.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
+      "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -5418,6 +5991,13 @@
         "@types/trusted-types": "*"
       }
     },
+    "node_modules/@types/doublearray": {
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/@types/doublearray/-/doublearray-0.0.32.tgz",
+      "integrity": "sha512-HloTru3I3a55runIVqZX1YBQi2L5A4peNQPh33yshzB4ttt1qHCnHPkuhy9Djy/cTx7i5xJvxItKRPCmvnfpGw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -5467,6 +6047,22 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/kuromoji": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@types/kuromoji/-/kuromoji-0.1.3.tgz",
+      "integrity": "sha512-u+YwX6eJj6Fmm0F5qunsyA+X8HSiyRNNE5ON3itD3tERax4meq9tv+S7bjTMXkPjqbdBGUmH2maGDCuEvpODwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/doublearray": "*"
+      }
+    },
+    "node_modules/@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
       "license": "MIT"
     },
     "node_modules/@types/minimatch": {
@@ -6236,6 +6832,43 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "node_modules/@xenova/transformers": {
+      "version": "2.17.2",
+      "resolved": "https://registry.npmjs.org/@xenova/transformers/-/transformers-2.17.2.tgz",
+      "integrity": "sha512-lZmHqzrVIkSvZdKZEx7IYY51TK0WDrC8eR0c5IMnBsO8di8are1zzw8BlLhyO2TklZKLN5UffNGs1IJwT6oOqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@huggingface/jinja": "^0.2.2",
+        "onnxruntime-web": "1.14.0",
+        "sharp": "^0.32.0"
+      },
+      "optionalDependencies": {
+        "onnxruntime-node": "1.14.0"
+      }
+    },
+    "node_modules/@xenova/transformers/node_modules/sharp": {
+      "version": "0.32.6",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.6.tgz",
+      "integrity": "sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.2",
+        "node-addon-api": "^6.1.0",
+        "prebuild-install": "^7.1.1",
+        "semver": "^7.5.4",
+        "simple-get": "^4.0.1",
+        "tar-fs": "^3.0.4",
+        "tunnel-agent": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -6682,6 +7315,20 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/b4a": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
+      "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/babel-loader": {
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.4.1.tgz",
@@ -6755,6 +7402,117 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.2.tgz",
+      "integrity": "sha512-veTnRzkb6aPHOvSKIOy60KzURfBdUflr5VReI+NSaPL6xf+XLdONQgZgpYvUuZLVQ8dCqxpBAudaOM1+KpAUxw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz",
+      "integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz",
+      "integrity": "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "streamx": "^2.21.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
+      "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.32",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.32.tgz",
@@ -6783,6 +7541,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/bn.js": {
@@ -6856,6 +7625,30 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -7063,6 +7856,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
     "node_modules/chrome-trace-event": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
@@ -7131,11 +7930,23 @@
         "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -7148,8 +7959,17 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/commander": {
       "version": "4.1.1",
@@ -7472,6 +8292,30 @@
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -7624,7 +8468,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -7725,6 +8568,12 @@
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
+    "node_modules/doublearray": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/doublearray/-/doublearray-0.0.2.tgz",
+      "integrity": "sha512-aw55FtZzT6AmiamEj2kvmR6BuFqvYgKZUkfQ7teqVRNqD5UE0rw8IeW/3gieHNKQ5sPuDKlljWEn4bzv5+1bHw==",
+      "license": "MIT"
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -7796,6 +8645,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -8000,6 +8858,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.1.tgz",
+      "integrity": "sha512-yY35KZckJJuVVPXpvjgxiCuVEJT67F6zDeVTv4rizyPrfGBUpZQsvmxnN+C371c2esD/hNMjj4tpBhuueLN7aA==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.1",
+        "@esbuild/android-arm": "0.27.1",
+        "@esbuild/android-arm64": "0.27.1",
+        "@esbuild/android-x64": "0.27.1",
+        "@esbuild/darwin-arm64": "0.27.1",
+        "@esbuild/darwin-x64": "0.27.1",
+        "@esbuild/freebsd-arm64": "0.27.1",
+        "@esbuild/freebsd-x64": "0.27.1",
+        "@esbuild/linux-arm": "0.27.1",
+        "@esbuild/linux-arm64": "0.27.1",
+        "@esbuild/linux-ia32": "0.27.1",
+        "@esbuild/linux-loong64": "0.27.1",
+        "@esbuild/linux-mips64el": "0.27.1",
+        "@esbuild/linux-ppc64": "0.27.1",
+        "@esbuild/linux-riscv64": "0.27.1",
+        "@esbuild/linux-s390x": "0.27.1",
+        "@esbuild/linux-x64": "0.27.1",
+        "@esbuild/netbsd-arm64": "0.27.1",
+        "@esbuild/netbsd-x64": "0.27.1",
+        "@esbuild/openbsd-arm64": "0.27.1",
+        "@esbuild/openbsd-x64": "0.27.1",
+        "@esbuild/openharmony-arm64": "0.27.1",
+        "@esbuild/sunos-x64": "0.27.1",
+        "@esbuild/win32-arm64": "0.27.1",
+        "@esbuild/win32-ia32": "0.27.1",
+        "@esbuild/win32-x64": "0.27.1"
       }
     },
     "node_modules/escalade": {
@@ -8520,6 +9420,24 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -8534,6 +9452,12 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -8722,6 +9646,12 @@
         "node": ">=16"
       }
     },
+    "node_modules/flatbuffers": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-1.12.0.tgz",
+      "integrity": "sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ==",
+      "license": "SEE LICENSE IN LICENSE.txt"
+    },
     "node_modules/flatted": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
@@ -8743,6 +9673,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "9.1.0",
@@ -8908,7 +9844,7 @@
       "version": "4.13.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
       "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -8916,6 +9852,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
@@ -9009,6 +9951,12 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/guid-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
+      "license": "ISC"
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -9168,6 +10116,26 @@
       "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
       "license": "ISC"
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -9221,6 +10189,12 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -9260,6 +10234,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT"
     },
     "node_modules/is-async-function": {
       "version": "2.1.1",
@@ -9941,6 +10921,26 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/kuromoji": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/kuromoji/-/kuromoji-0.1.2.tgz",
+      "integrity": "sha512-V0dUf+C2LpcPEXhoHLMAop/bOht16Dyr+mDiIE39yX3vqau7p80De/koFqpiTcL1zzdZlc3xuHZ8u5gjYRfFaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async": "^2.0.1",
+        "doublearray": "0.0.2",
+        "zlibjs": "^0.3.1"
+      }
+    },
+    "node_modules/kuromoji/node_modules/async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
     "node_modules/language-subtag-registry": {
       "version": "0.3.23",
       "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
@@ -10071,6 +11071,12 @@
       "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
       "license": "MIT"
     },
+    "node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -10194,6 +11200,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -10220,6 +11238,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/mnemonist": {
       "version": "0.38.3",
@@ -10264,6 +11288,12 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
     },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
@@ -10419,6 +11449,24 @@
         "react": ">= 16.0.0",
         "react-dom": ">= 16.0.0"
       }
+    },
+    "node_modules/node-abi": {
+      "version": "3.85.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.85.0.tgz",
+      "integrity": "sha512-zsFhmbkAzwhTft6nd3VxcG0cvJsT70rL+BIGHWVq5fi6MwGrHwzqKaxXE+Hl2GmnGItnDKPPkO5/LQqjVkIdFg==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
+      "license": "MIT"
     },
     "node_modules/node-cron": {
       "version": "4.2.1",
@@ -10603,6 +11651,50 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/onnx-proto": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/onnx-proto/-/onnx-proto-4.0.4.tgz",
+      "integrity": "sha512-aldMOB3HRoo6q/phyB6QRQxSt895HNNw82BNyZ2CMh4bjeKv7g/c+VpAFtJuEMVfYLMbRx61hbuqnKceLeDcDA==",
+      "license": "MIT",
+      "dependencies": {
+        "protobufjs": "^6.8.8"
+      }
+    },
+    "node_modules/onnxruntime-common": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.14.0.tgz",
+      "integrity": "sha512-3LJpegM2iMNRX2wUmtYfeX/ytfOzNwAWKSq1HbRrKc9+uqG/FsEA0bbKZl1btQeZaXhC26l44NWpNUeXPII7Ew==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-node": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.14.0.tgz",
+      "integrity": "sha512-5ba7TWomIV/9b6NH/1x/8QEeowsb+jBEvFzU6z0T4mNsFwdPqXeFUM7uxC6QeSRkEbWu3qEB0VMjrvzN/0S9+w==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "onnxruntime-common": "~1.14.0"
+      }
+    },
+    "node_modules/onnxruntime-web": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.14.0.tgz",
+      "integrity": "sha512-Kcqf43UMfW8mCydVGcX9OMXI2VN17c0p6XvR7IPSZzBf/6lteBzXHvcEVWDPmCKuGombl997HgLqj91F11DzXw==",
+      "license": "MIT",
+      "dependencies": {
+        "flatbuffers": "^1.12.0",
+        "guid-typescript": "^1.0.9",
+        "long": "^4.0.0",
+        "onnx-proto": "^4.0.4",
+        "onnxruntime-common": "~1.14.0",
+        "platform": "^1.3.6"
       }
     },
     "node_modules/openid-client": {
@@ -10935,6 +12027,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT"
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -11100,6 +12198,60 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -11131,6 +12283,42 @@
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "6.11.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
+      "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "pbjs": "bin/pbjs",
+        "pbts": "bin/pbts"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -11169,6 +12357,30 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/react": {
@@ -11324,6 +12536,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/readdirp": {
@@ -11514,7 +12740,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -11713,7 +12939,6 @@
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -11917,6 +13142,60 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -11985,6 +13264,26 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
+      "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string.prototype.includes": {
@@ -12315,6 +13614,31 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
+      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
     "node_modules/temp-dir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
@@ -12465,6 +13789,15 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
+    "node_modules/text-decoder": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -12614,6 +13947,38 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -13614,6 +14979,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zlibjs": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
+      "integrity": "sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build:search-index": "tsx scripts/build-search-index.ts",
+    "build": "npm run build:search-index && next build",
     "start": "next start",
     "lint": "next lint"
   },
@@ -15,6 +16,7 @@
     "@aws-sdk/lib-dynamodb": "^3.726.1",
     "@aws-sdk/util-dynamodb": "^3.726.1",
     "@next/third-parties": "15.5.9",
+    "@orama/orama": "^3.0.0",
     "@radix-ui/react-accordion": "^1.2.2",
     "@radix-ui/react-avatar": "^1.1.2",
     "@radix-ui/react-checkbox": "^1.1.3",
@@ -30,11 +32,14 @@
     "@radix-ui/react-slot": "^1.1.1",
     "@radix-ui/react-switch": "^1.1.2",
     "@radix-ui/react-tooltip": "^1.1.6",
+    "@radix-ui/react-visually-hidden": "^1.2.4",
     "@types/cheerio": "^0.22.35",
+    "@xenova/transformers": "^2.17.0",
     "cheerio": "^1.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "kuromoji": "^0.1.2",
     "lucide-react": "^0.469.0",
     "next": "15.5.9",
     "next-pwa": "^5.6.0",
@@ -55,6 +60,7 @@
   },
   "devDependencies": {
     "@types/dompurify": "^3.0.5",
+    "@types/kuromoji": "^0.1.3",
     "@types/node": "^20",
     "@types/node-cron": "^3.0.11",
     "@types/react": "19.2.7",
@@ -65,6 +71,7 @@
     "postcss": "^8",
     "sharp": "^0.34.3",
     "tailwindcss": "^3.4.1",
+    "tsx": "^4.7.0",
     "typescript": "^5"
   }
 }

--- a/scripts/build-search-index.ts
+++ b/scripts/build-search-index.ts
@@ -228,7 +228,7 @@ async function main() {
   console.log('📖 テキストファイルを処理中...');
   const textDir = path.join(contentsDir, 'text');
   if (fs.existsSync(textDir)) {
-    const textFiles = getFilesRecursively(textDir, /^\d{2}\.tsx$/);
+    const textFiles = getFilesRecursively(textDir, /^\d+\.tsx$/);
     const textStartCount = documents.length;
     
     for (const filePath of textFiles) {

--- a/scripts/build-search-index.ts
+++ b/scripts/build-search-index.ts
@@ -207,13 +207,15 @@ async function main() {
   // クイズファイルを処理
   console.log('📝 クイズファイルを処理中...');
   const quizDir = path.join(contentsDir, 'quiz');
-  const quizFiles = getFilesRecursively(quizDir, /^\d{2}\.tsx$/);
-  
-  for (const filePath of quizFiles) {
-    const content = fs.readFileSync(filePath, 'utf-8');
-    const data = extractQuizData(filePath, content);
-    if (data) {
-      documents.push(data);
+  if (fs.existsSync(quizDir)) {
+    const quizFiles = getFilesRecursively(quizDir, /^\d{2}\.tsx$/);
+    
+    for (const filePath of quizFiles) {
+      const content = fs.readFileSync(filePath, 'utf-8');
+      const data = extractQuizData(filePath, content);
+      if (data) {
+        documents.push(data);
+      }
     }
   }
   console.log(`✅ ${documents.length}件のクイズを処理しました\n`);

--- a/scripts/build-search-index.ts
+++ b/scripts/build-search-index.ts
@@ -28,8 +28,10 @@ interface SearchDocument {
 // クイズファイルからメタデータとコンテンツを抽出
 function extractQuizData(filePath: string, fileContent: string): Omit<SearchDocument, 'embedding'> | null {
   try {
+    // パスを正規化（Windowsのバックスラッシュをスラッシュに変換）
+    const normalizedPath = filePath.replace(/\\/g, '/');
     // クイズIDを抽出（ファイルパスから）
-    const pathMatch = filePath.match(/quiz\/(\d{4})\/(\d{2})\/(\d{2})\.tsx$/);
+    const pathMatch = normalizedPath.match(/quiz\/(\d{4})\/(\d{2})\/(\d{2})\.tsx$/);
     if (!pathMatch) return null;
 
     const [, year, month, day] = pathMatch;
@@ -99,8 +101,10 @@ function extractQuizData(filePath: string, fileContent: string): Omit<SearchDocu
 // テキストファイルからメタデータとコンテンツを抽出
 function extractTextData(filePath: string, fileContent: string): Omit<SearchDocument, 'embedding'> | null {
   try {
+    // パスを正規化（Windowsのバックスラッシュをスラッシュに変換）
+    const normalizedPath = filePath.replace(/\\/g, '/');
     // パスからIDを生成
-    const pathMatch = filePath.match(/text\/([^/]+)\/(\d+)\.tsx$/);
+    const pathMatch = normalizedPath.match(/text\/([^/]+)\/(\d+)\.tsx$/);
     if (!pathMatch) return null;
 
     const [, category, pageNum] = pathMatch;

--- a/scripts/build-search-index.ts
+++ b/scripts/build-search-index.ts
@@ -9,7 +9,7 @@
 import fs from 'fs';
 import path from 'path';
 import { create, insertMultiple, save } from '@orama/orama';
-import { getTokenizer } from '../lib/search/tokenizer';
+import { getTokenizer, createOramaTokenizer } from '../lib/search/tokenizer';
 import { generateEmbeddings, getEmbeddingDimension } from '../lib/search/embedder';
 
 // インデックスに格納するドキュメントの型
@@ -268,6 +268,9 @@ async function main() {
       url: 'string',
       createdAt: 'string',
       embedding: `vector[${getEmbeddingDimension()}]`,
+    },
+    components: {
+      tokenizer: createOramaTokenizer(),
     },
   });
 

--- a/scripts/build-search-index.ts
+++ b/scripts/build-search-index.ts
@@ -1,0 +1,287 @@
+/**
+ * 検索インデックス生成スクリプト
+ * 
+ * クイズとテキストコンテンツからOramaインデックスを生成する
+ * 
+ * 使用方法: npm run build:search-index
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { create, insertMultiple, save } from '@orama/orama';
+import { getTokenizer } from '../lib/search/tokenizer';
+import { generateEmbeddings, getEmbeddingDimension } from '../lib/search/embedder';
+
+// インデックスに格納するドキュメントの型
+interface SearchDocument {
+  id: string;
+  type: 'quiz' | 'text';
+  title: string;
+  content: string;
+  tags: string[];
+  author: string;
+  url: string;
+  createdAt: string;
+  embedding: number[];
+}
+
+// クイズファイルからメタデータとコンテンツを抽出
+function extractQuizData(filePath: string, fileContent: string): Omit<SearchDocument, 'embedding'> | null {
+  try {
+    // クイズIDを抽出（ファイルパスから）
+    const pathMatch = filePath.match(/quiz\/(\d{4})\/(\d{2})\/(\d{2})\.tsx$/);
+    if (!pathMatch) return null;
+
+    const [, year, month, day] = pathMatch;
+    const quizId = `Q${year}${month}${day}`;
+    const url = `/quiz/${year}/${month}/${day}`;
+
+    // タイトルを抽出
+    const titleMatch = fileContent.match(/title:\s*["'`]([^"'`]+)["'`]/);
+    const title = titleMatch ? titleMatch[1] : `クイズ ${year}/${month}/${day}`;
+
+    // タグを抽出
+    const tagsMatch = fileContent.match(/tags:\s*\[([^\]]+)\]/);
+    let tags: string[] = [];
+    if (tagsMatch) {
+      tags = tagsMatch[1]
+        .split(',')
+        .map(tag => tag.trim().replace(/["'`]/g, ''))
+        .filter(tag => tag.length > 0);
+    }
+
+    // 作成者を抽出
+    const authorMatch = fileContent.match(/author:\s*["'`]([^"'`]+)["'`]/);
+    const author = authorMatch ? authorMatch[1] : '';
+
+    // 作成日を抽出
+    const createdAtMatch = fileContent.match(/created_at:\s*new Date\(["'`]([^"'`]+)["'`]\)/);
+    const createdAt = createdAtMatch ? createdAtMatch[1] : `${year}-${month}-${day}`;
+
+    // 選択肢を抽出
+    const optionsMatch = fileContent.match(/options:\s*\{([^}]+)\}/s);
+    let options: string[] = [];
+    if (optionsMatch) {
+      const optionsContent = optionsMatch[1];
+      const optionMatches = optionsContent.matchAll(/\d+:\s*["'`]([^"'`]+)["'`]/g);
+      for (const match of optionMatches) {
+        options.push(match[1]);
+      }
+    }
+
+    // JSXコンポーネントからテキストを抽出
+    const content = extractTextFromJsx(fileContent);
+
+    // コンテンツを結合
+    const fullContent = [
+      title,
+      ...tags,
+      content,
+      ...options,
+    ].join(' ');
+
+    return {
+      id: quizId,
+      type: 'quiz',
+      title,
+      content: fullContent,
+      tags,
+      author,
+      url,
+      createdAt,
+    };
+  } catch (error) {
+    console.error(`Error extracting quiz data from ${filePath}:`, error);
+    return null;
+  }
+}
+
+// テキストファイルからメタデータとコンテンツを抽出
+function extractTextData(filePath: string, fileContent: string): Omit<SearchDocument, 'embedding'> | null {
+  try {
+    // パスからIDを生成
+    const pathMatch = filePath.match(/text\/([^/]+)\/(\d+)\.tsx$/);
+    if (!pathMatch) return null;
+
+    const [, category, pageNum] = pathMatch;
+    const textId = `T_${category}_${pageNum}`;
+    const url = `/text/${category}/${pageNum}`;
+
+    // タイトルを抽出（h1タグまたはページ名から）
+    let title = `${category} - ページ${pageNum}`;
+    const h1Match = fileContent.match(/<h1[^>]*>([^<]+)<\/h1>/);
+    if (h1Match) {
+      title = h1Match[1].replace(/\{[^}]+\}/g, '').trim();
+    }
+
+    // JSXからテキストを抽出
+    const content = extractTextFromJsx(fileContent);
+
+    return {
+      id: textId,
+      type: 'text',
+      title,
+      content,
+      tags: [category],
+      author: '',
+      url,
+      createdAt: '',
+    };
+  } catch (error) {
+    console.error(`Error extracting text data from ${filePath}:`, error);
+    return null;
+  }
+}
+
+// JSXからテキストを抽出（HTMLタグとJSX構文を除去）
+function extractTextFromJsx(content: string): string {
+  // import文を除去
+  let text = content.replace(/import\s+.*?from\s+['"][^'"]+['"];?\n?/g, '');
+  
+  // export defaultやfunction宣言を除去
+  text = text.replace(/export\s+default\s+function\s+\w+\s*\(\)\s*\{/g, '');
+  text = text.replace(/function\s+\w+\s*\(\)\s*\{/g, '');
+  
+  // JSXコンポーネント呼び出しを除去
+  text = text.replace(/<\w+\s*\/>/g, '');
+  text = text.replace(/<\/?\w+[^>]*>/g, ' ');
+  
+  // JSX属性を除去
+  text = text.replace(/\w+={[^}]+}/g, '');
+  text = text.replace(/className="[^"]*"/g, '');
+  
+  // コード記号を除去
+  text = text.replace(/[{}\[\]()<>\/\\=;:'"`,]/g, ' ');
+  
+  // constやletなどの宣言を除去
+  text = text.replace(/\b(const|let|var|return|new|Date|Quiz)\b/g, ' ');
+  
+  // 複数の空白を1つに
+  text = text.replace(/\s+/g, ' ').trim();
+  
+  return text;
+}
+
+// ファイルを再帰的に取得
+function getFilesRecursively(dir: string, pattern: RegExp): string[] {
+  const files: string[] = [];
+  
+  function walk(currentDir: string) {
+    const entries = fs.readdirSync(currentDir, { withFileTypes: true });
+    
+    for (const entry of entries) {
+      const fullPath = path.join(currentDir, entry.name);
+      
+      if (entry.isDirectory()) {
+        walk(fullPath);
+      } else if (entry.isFile() && pattern.test(entry.name)) {
+        files.push(fullPath);
+      }
+    }
+  }
+  
+  walk(dir);
+  return files;
+}
+
+async function main() {
+  console.log('🔍 検索インデックス生成を開始します...\n');
+
+  const rootDir = process.cwd();
+  const contentsDir = path.join(rootDir, 'contents');
+  const outputPath = path.join(rootDir, 'data', 'search-index.json');
+
+  // 出力ディレクトリを作成
+  const outputDir = path.dirname(outputPath);
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  }
+
+  // kuromojiトークナイザーを初期化
+  console.log('📚 形態素解析器を初期化中...');
+  await getTokenizer();
+  console.log('✅ 形態素解析器の初期化完了\n');
+
+  const documents: Omit<SearchDocument, 'embedding'>[] = [];
+
+  // クイズファイルを処理
+  console.log('📝 クイズファイルを処理中...');
+  const quizDir = path.join(contentsDir, 'quiz');
+  const quizFiles = getFilesRecursively(quizDir, /^\d{2}\.tsx$/);
+  
+  for (const filePath of quizFiles) {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    const data = extractQuizData(filePath, content);
+    if (data) {
+      documents.push(data);
+    }
+  }
+  console.log(`✅ ${documents.length}件のクイズを処理しました\n`);
+
+  // テキストファイルを処理
+  console.log('📖 テキストファイルを処理中...');
+  const textDir = path.join(contentsDir, 'text');
+  if (fs.existsSync(textDir)) {
+    const textFiles = getFilesRecursively(textDir, /^\d{2}\.tsx$/);
+    const textStartCount = documents.length;
+    
+    for (const filePath of textFiles) {
+      const content = fs.readFileSync(filePath, 'utf-8');
+      const data = extractTextData(filePath, content);
+      if (data) {
+        documents.push(data);
+      }
+    }
+    console.log(`✅ ${documents.length - textStartCount}件のテキストを処理しました\n`);
+  }
+
+  console.log(`📊 合計: ${documents.length}件のドキュメント\n`);
+
+  // Embeddingを生成
+  console.log('🧠 Embeddingを生成中...');
+  const contents = documents.map(doc => doc.content);
+  const embeddings = await generateEmbeddings(contents);
+  console.log('✅ Embedding生成完了\n');
+
+  // ドキュメントにembeddingを追加
+  const documentsWithEmbedding: SearchDocument[] = documents.map((doc, i) => ({
+    ...doc,
+    embedding: embeddings[i],
+  }));
+
+  // Oramaインデックスを作成
+  console.log('🏗️ 検索インデックスを構築中...');
+  const db = await create({
+    schema: {
+      id: 'string',
+      type: 'string',
+      title: 'string',
+      content: 'string',
+      tags: 'string[]',
+      author: 'string',
+      url: 'string',
+      createdAt: 'string',
+      embedding: `vector[${getEmbeddingDimension()}]`,
+    },
+  });
+
+  // ドキュメントを挿入
+  await insertMultiple(db, documentsWithEmbedding);
+  console.log('✅ インデックス構築完了\n');
+
+  // インデックスを保存
+  console.log('💾 インデックスを保存中...');
+  const serialized = await save(db);
+  fs.writeFileSync(outputPath, JSON.stringify(serialized));
+  
+  const fileSizeKB = (fs.statSync(outputPath).size / 1024).toFixed(2);
+  console.log(`✅ インデックスを保存しました: ${outputPath} (${fileSizeKB} KB)\n`);
+
+  console.log('🎉 検索インデックス生成が完了しました！');
+}
+
+main().catch((error) => {
+  console.error('エラーが発生しました:', error);
+  process.exit(1);
+});
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,7 @@
         "./*"
       ]
     },
-    "target": "ES2017"
+    "target": "ES2018"
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
サーチ機能の追加


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce authenticated site-wide search (hybrid fulltext+vector) with a command palette UI, Orama index + embeddings, and build/Docker support.
> 
> - **Search Backend**:
>   - Add `GET /api/search` with validation, supports `hybrid`/`fulltext`/`vector`, content filters, tags, `minScore`, and result snippets (`app/api/search/route.ts`).
>   - Implement search stack: `lib/search/tokenizer.ts` (kuromoji), `lib/search/embedder.ts` (Xenova e5), `lib/search/orama-client.ts` (Orama v3 fulltext/vector/hybrid), and re-exports in `lib/search/index.ts`.
> - **Index Build Pipeline**:
>   - New script to generate Orama index from `contents` (quizzes/text) with embeddings; outputs `data/search-index.json` (`scripts/build-search-index.ts`).
>   - Wire into build (`package.json` `build:search-index` → `build`).
> - **UI/UX**:
>   - Add command-palette search dialog with debounce, grouping, keyboard shortcut (Cmd/Ctrl+K), and auth gate (`components/search/search-command.tsx`).
>   - Integrate provider/dialog into layout and sidebar trigger (`app/layout.tsx`, `components/app-sidebar.tsx`).
>   - Minor dialog a11y/spacing tweaks (`components/ui/command.tsx`, `components/auth-dialog.tsx`).
> - **Infra/Docker**:
>   - Copy `data/` index and kuromoji `dict`, configure writable transformers cache, symlink `.next/cache`, set `TRANSFORMERS_CACHE` (`Dockerfile`).
> - **Config/Deps**:
>   - Add `@orama/orama`, `@xenova/transformers`, `kuromoji`, Radix visually-hidden, `tsx`, and related transitive deps; update TS target to `ES2018`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd959918da502e799b3f2e8d2e7a8c8996f520f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->